### PR TITLE
Fix S3 CI build (gate ip101 to esp32p4) + ship the esp32p4-eth firmware

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        firmware: [esp32, esp32-16mb, esp32-eth, esp32-eth-wifi, esp32s3-n16r8, esp32s3-n8r8]
+        firmware: [esp32, esp32-16mb, esp32-eth, esp32-eth-wifi, esp32s3-n16r8, esp32s3-n8r8, esp32p4-eth]
     steps:
       - uses: actions/checkout@v4
 
@@ -112,8 +112,13 @@ jobs:
           # `v6.1-dev` is a rolling Docker tag on espressif/idf that tracks the
           # v6.1 dev line — close enough to the pinned SHA for CI today.
           esp_idf_version: v6.1-dev
-          # Any firmware whose key starts with `esp32s3` targets the S3.
-          target: ${{ startsWith(matrix.firmware, 'esp32s3') && 'esp32s3' || 'esp32' }}
+          # The IDF target follows the firmware-key prefix: esp32s3* → esp32s3,
+          # esp32p4* → esp32p4 (the only target that pulls the ip101 PHY +
+          # esp_hosted, both manifest-gated on target == esp32p4), everything
+          # else → esp32. (esp32p4-eth-wifi is intentionally NOT in the matrix
+          # yet — its C6-slave Kconfig defaults don't survive a plain CI build;
+          # tracked in backlog § ESP32-P4 round 3.)
+          target: ${{ startsWith(matrix.firmware, 'esp32s3') && 'esp32s3' || startsWith(matrix.firmware, 'esp32p4') && 'esp32p4' || 'esp32' }}
           path: 'esp32'
           # We run our own builder (not the action's default `idf.py build`)
           # so the sdkconfig fragments and EXCLUDE_COMPONENTS go through the
@@ -233,7 +238,7 @@ jobs:
           # Keep in sync with the build-esp32 matrix above (the source of truth
           # for which firmware variants exist). A variant missing here builds but
           # gets no manifest, so the installer can't flash it.
-          for F in esp32 esp32-16mb esp32-eth esp32-eth-wifi esp32s3-n16r8 esp32s3-n8r8; do
+          for F in esp32 esp32-16mb esp32-eth esp32-eth-wifi esp32s3-n16r8 esp32s3-n8r8 esp32p4-eth; do
             python scripts/build/generate_manifest.py \
               --firmware "$F" \
               --version "$V" \
@@ -344,7 +349,7 @@ jobs:
           # Keep in sync with the build-esp32 matrix above (the source of truth
           # for which firmware variants exist). A variant missing here builds but
           # gets no manifest, so the installer can't flash it.
-          for F in esp32 esp32-16mb esp32-eth esp32-eth-wifi esp32s3-n16r8 esp32s3-n8r8; do
+          for F in esp32 esp32-16mb esp32-eth esp32-eth-wifi esp32s3-n16r8 esp32s3-n8r8 esp32p4-eth; do
             python scripts/build/generate_manifest.py \
               --firmware "$F" \
               --version "$V" \

--- a/docs/backlog/backlog.md
+++ b/docs/backlog/backlog.md
@@ -10,7 +10,7 @@ Completed items are removed. This file is deleted when empty.
 
 1.0 ships ESP32 firmware (4 variants) + macOS arm64 + Windows x64. Still to add:
 
-- **ESP32-P4** firmware variant — new chip target, new sdkconfig fragment, fits the existing `FIRMWARES` table in `build_esp32.py`.
+- **ESP32-P4** firmware variant — **`esp32p4-eth` (Ethernet-only) shipped**: in `build_esp32.py`'s `FIRMWARES`, the `boards.json` catalog (Waveshare P4-NANO), and CI builds + publishes it to the web installer + releases. **Still to ship: `esp32p4-eth-wifi`** (the C6-WiFi variant) — it doesn't build reproducibly in CI yet (the `CONFIG_WIFI_RMT_*` Kconfig defaults don't survive a plain build without a fresh `set-target`), so it's held out of the release matrix until that's fixed; see [§ ESP32-P4 round 3](#esp32-p4-support--rounds-3-4-in-progress).
 - **Linux desktop binary** — third desktop job in `release.yml`, static-linked libstdc++.
 - **Teensy 4.1** — toolchain-file build, `.hex` for Teensy Loader.
 - **Raspberry Pi** — ARM64, cross-built or native.

--- a/esp32/main/idf_component.yml
+++ b/esp32/main/idf_component.yml
@@ -7,10 +7,19 @@ dependencies:
     version: "^1.2.5"
   # IP101 Ethernet PHY for the ESP32-P4-NANO. IDF v6 moved the per-PHY drivers
   # out of esp_eth core into managed components; only referenced on the P4 build
-  # (ethInit's IP101 ctor is behind if constexpr). The generic PHY (Olimex
-  # LAN8720) stays in core, so non-P4 builds don't pull this.
+  # (ethInit's IP101 ctor is behind `#ifdef CONFIG_IDF_TARGET_ESP32P4`; the
+  # generic PHY, Olimex LAN8720, stays in core). The `rules` gate scopes the
+  # *dependency* to the P4 too — without it, every target tries to resolve ip101
+  # even though only the P4 compiles the symbol, and the **S3 build fails the
+  # solve**: ip101 is an EMAC PHY, the registry has no esp32s3-compatible version
+  # (the S3 has no internal EMAC), so `^1.0.0` "doesn't match any versions". The
+  # classic/P4 (which have an EMAC) resolve it fine, but the gate is still correct
+  # for them since they never compile it. Only bites in a fresh CI solve; a local
+  # build with a committed lock masks it.
   espressif/ip101:
     version: "^1.0.0"
+    rules:
+      - if: "target == esp32p4"
   # esp-dsp — Espressif's signal-processing library; we use its float radix-2 FFT
   # (dsps_fft2r_fc32) for the microphone spectrum. Float (not fixed-point) because
   # every mic-capable target here has an FPU, where float is faster. Referenced


### PR DESCRIPTION
The post-merge release CI failed on both ESP32-S3 firmwares with "espressif/ip101 (^1.0.0) which doesn't match any versions". Two fixes: gate the ip101 dependency to the P4 (the only target that compiles it), and add the now-buildable esp32p4-eth firmware to the CI matrix + web installer so it ships to users and CI actually exercises the gated P4 path.

Docs / CI
- esp32/main/idf_component.yml: added `rules: target == esp32p4` to espressif/ip101 (was unconditional). ip101 is an EMAC PHY and the registry has no esp32s3-compatible version (the S3 has no internal EMAC), so a fresh CI solve — the dependencies.lock is gitignored, so CI never has it — fails on the S3 with "doesn't match any versions". classic/P4 (which have an EMAC) resolved it fine, which is why only the S3 jobs failed. Only the P4 build compiles the symbol (ethInit's IP101 ctor is behind `#ifdef CONFIG_IDF_TARGET_ESP32P4`; the generic LAN8720 PHY stays in esp_eth core), so gating to esp32p4 — the same `rules` pattern as esp_wifi_remote / esp_hosted — is correct: non-P4 targets skip a component they never build. Verified locally: S3 now skips ip101 and completes; P4 still pulls ip101 (1.0.0) and completes.
- .github/workflows/release.yml: added esp32p4-eth to the build matrix and both manifest/release loops, and extended the IDF-target expression to map esp32p4* → esp32p4. CI now builds + publishes the Ethernet-only P4 firmware to the web installer (the boards.json Waveshare P4-NANO entry already points at it) and to GitHub release assets. This also makes CI exercise the ip101 gate (P4 is the only target that pulls it). esp32p4-eth-wifi is deliberately NOT in the matrix yet — it doesn't build reproducibly in CI (the C6-slave CONFIG_WIFI_RMT_* Kconfig defaults don't survive a plain build), tracked in backlog § ESP32-P4 round 3.
- backlog: marked the ESP32-P4 firmware-variant distribution item as eth-shipped / eth-wifi-pending, with the build-reproducibility blocker noted.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
