### PR TITLE
Improve frame pacing and RGBW LED output

### DIFF
--- a/docs/moonmodules/light/drivers.md
+++ b/docs/moonmodules/light/drivers.md
@@ -18,6 +18,8 @@ Addressable WS2812B-class LEDs over a wire, one GPIO per strand. Three periphera
 
 - `pins` — data GPIO list, e.g. `18,17,16` (one strand each). Empty idles until set; changing it re-inits live.
 - `ledsPerPin` — lights per pin, matched by position; empty or short = even split of the remainder.
+- `chipset` - wire timing profile, currently `WS2812B` or `SK6812 RGBW`.
+- `backend` - display-only output backend, e.g. `RMT DMA` when DMA streaming is active.
 - `loopbackTest` — on/off TX→RX loopback self-test (jumper the first pin to `loopbackRxPin`); verdict in the status field.
 - `loopbackTxPin` / `loopbackRxPin` — optional TX override + the RX pin for the self-test. Shown only while `loopbackTest` is on.
 
@@ -89,7 +91,7 @@ Detail: [technical](moxygen/PreviewDriver.md)
 
 ## LED output — details
 
-The three LED-output peripherals, compared. All drive WS2812B-class strips with the same `pins` / `ledsPerPin` / `loopback*` controls and the same wire contract; they differ in parallelism and chip.
+The three LED-output peripherals, compared. All drive WS2812B/SK6812-class strips with the same `pins` / `ledsPerPin` / `chipset` / `loopback*` controls and the same wire contract; they differ in parallelism and chip.
 
 | Peripheral | Chip | Strands | Notes |
 |------------|------|---------|-------|

--- a/src/core/FileManagerModule.cpp
+++ b/src/core/FileManagerModule.cpp
@@ -17,13 +17,8 @@ void FileManagerModule::onBuildControls() {
     // `show hidden` flag keeps it bound for the API while the generic control list skips it.
     controls_.addBool("show hidden", showHidden_);      // reveal dot-prefixed entries (e.g. .config)
     controls_.setHidden(controls_.count() - 1, true);
-    // Filesystem-usage gauge (used / total bytes), read from the platform. Shown below the tree in
-    // the panel — the File Manager is where filesystem space is relevant, so it owns the control.
-    // Bound only when the platform reports a real partition (desktop / a no-data-partition chip
-    // reports 0). loop1s refreshes the used value sparingly; the total is fixed.
-    totalBytes_ = static_cast<uint32_t>(platform::filesystemTotal());
-    usedBytes_ = static_cast<uint32_t>(platform::filesystemUsed());
-    lastUsageRefreshMs_ = platform::millis();
+    // Filesystem-usage gauge (used / total bytes), shown below the tree in the panel. setup() and
+    // loop1s refresh the cached values; control rebuilds only rebind descriptors.
     if (totalBytes_ > 0) {
         controls_.addProgress("filesystem", usedBytes_, totalBytes_);
         controls_.setHidden(controls_.count() - 1, true);   // renders as the usage bar in the panel, not generically
@@ -47,10 +42,7 @@ void FileManagerModule::loop1s() {
     const uint32_t now = platform::millis();
     if (lastUsageRefreshMs_ != 0 && now - lastUsageRefreshMs_ < kUsageRefreshMs) return;
 
-    // LittleFS usage accounting can take tens of milliseconds on ESP32; keep it
-    // off the once-per-second housekeeping burst while LED output is active.
-    lastUsageRefreshMs_ = now;
-    usedBytes_ = static_cast<uint32_t>(platform::filesystemUsed());
+    refreshUsage();
 }
 
 void FileManagerModule::setup() {
@@ -59,6 +51,22 @@ void FileManagerModule::setup() {
     // regardless of any persisted value (setup() runs after persistence overlays it). A file manager
     // opens with hidden entries hidden; the user re-toggles per session.
     showHidden_ = false;
+    refreshUsage();
+    rebuildControls();
+}
+
+void FileManagerModule::refreshUsage() {
+    totalBytes_ = static_cast<uint32_t>(platform::filesystemTotal());
+    if (totalBytes_ == 0) {
+        usedBytes_ = 0;
+        lastUsageRefreshMs_ = 0;
+        return;
+    }
+
+    // LittleFS usage accounting can take tens of milliseconds on ESP32; keep it
+    // out of onBuildControls(), which can run after ordinary control writes.
+    usedBytes_ = static_cast<uint32_t>(platform::filesystemUsed());
+    lastUsageRefreshMs_ = platform::millis();
 }
 
 // mkdir/delete are HTTP endpoints (POST/DELETE /api/dir?path=) in HttpServerModule: a create/delete

--- a/src/core/FileManagerModule.cpp
+++ b/src/core/FileManagerModule.cpp
@@ -5,6 +5,10 @@
 
 namespace mm {
 
+namespace {
+constexpr uint32_t kUsageRefreshMs = 5u * 60u * 1000u;
+}
+
 void FileManagerModule::onBuildControls() {
     // Only `show hidden` is a control: the whole File Manager surface is the tree panel (app.js
     // renderFileManager), which lists over /api/dir and reads the gauges from /api/state; the
@@ -16,9 +20,10 @@ void FileManagerModule::onBuildControls() {
     // Filesystem-usage gauge (used / total bytes), read from the platform. Shown below the tree in
     // the panel — the File Manager is where filesystem space is relevant, so it owns the control.
     // Bound only when the platform reports a real partition (desktop / a no-data-partition chip
-    // reports 0). loop1s refreshes the used value; the total is fixed.
+    // reports 0). loop1s refreshes the used value sparingly; the total is fixed.
     totalBytes_ = static_cast<uint32_t>(platform::filesystemTotal());
     usedBytes_ = static_cast<uint32_t>(platform::filesystemUsed());
+    lastUsageRefreshMs_ = platform::millis();
     if (totalBytes_ > 0) {
         controls_.addProgress("filesystem", usedBytes_, totalBytes_);
         controls_.setHidden(controls_.count() - 1, true);   // renders as the usage bar in the panel, not generically
@@ -37,7 +42,15 @@ void FileManagerModule::onBuildControls() {
 }
 
 void FileManagerModule::loop1s() {
-    if (totalBytes_ > 0) usedBytes_ = static_cast<uint32_t>(platform::filesystemUsed());
+    if (totalBytes_ == 0) return;
+
+    const uint32_t now = platform::millis();
+    if (lastUsageRefreshMs_ != 0 && now - lastUsageRefreshMs_ < kUsageRefreshMs) return;
+
+    // LittleFS usage accounting can take tens of milliseconds on ESP32; keep it
+    // off the once-per-second housekeeping burst while LED output is active.
+    lastUsageRefreshMs_ = now;
+    usedBytes_ = static_cast<uint32_t>(platform::filesystemUsed());
 }
 
 void FileManagerModule::setup() {

--- a/src/core/FileManagerModule.h
+++ b/src/core/FileManagerModule.h
@@ -50,6 +50,8 @@ public:
     void loop1s() override;
 
 private:
+    void refreshUsage();
+
     bool showHidden_ = false;      // reveal dot-prefixed entries (forwarded to /api/dir by the UI)
     uint32_t usedBytes_ = 0;       // "filesystem" progress: bytes used, refreshed sparingly
     uint32_t totalBytes_ = 0;      // "filesystem" progress: partition total, read once at build

--- a/src/core/FileManagerModule.h
+++ b/src/core/FileManagerModule.h
@@ -51,8 +51,9 @@ public:
 
 private:
     bool showHidden_ = false;      // reveal dot-prefixed entries (forwarded to /api/dir by the UI)
-    uint32_t usedBytes_ = 0;       // "filesystem" progress: bytes used, refreshed in loop1s
+    uint32_t usedBytes_ = 0;       // "filesystem" progress: bytes used, refreshed sparingly
     uint32_t totalBytes_ = 0;      // "filesystem" progress: partition total, read once at build
+    uint32_t lastUsageRefreshMs_ = 0;
 };
 
 } // namespace mm

--- a/src/core/Scheduler.cpp
+++ b/src/core/Scheduler.cpp
@@ -64,21 +64,21 @@ void Scheduler::setup() {
 
 void Scheduler::tick() {
     uint32_t tickStart = platform::micros();
+    bool renderedFrame = false;
 
-    if (lastFrameStartUs_ != 0) {
-        const uint32_t targetFrameUs = 1000000u / targetFps_;
-        const uint32_t dueUs = lastFrameStartUs_ + targetFrameUs;
-        for (;;) {
-            const uint32_t nowUs = platform::micros();
-            if (static_cast<int32_t>(nowUs - dueUs) >= 0) break;
-            const uint32_t remainingUs = dueUs - nowUs;
-            if (remainingUs >= 2000) platform::delayMs(remainingUs / 1000);
-            else platform::yield();
-        }
-    }
-    lastFrameStartUs_ = platform::micros();
-    const uint32_t workStartUs = lastFrameStartUs_;
     uint32_t now = platform::millis();
+    const uint32_t targetFrameUs = 1000000u / targetFps_;
+    if (lastFrameStartUs_ != 0) {
+        const uint32_t nowUs = platform::micros();
+        if (static_cast<int32_t>(nowUs - (lastFrameStartUs_ + targetFrameUs)) >= 0) {
+            renderedFrame = true;
+            lastFrameStartUs_ = nowUs;
+        }
+    } else {
+        renderedFrame = true;
+        lastFrameStartUs_ = platform::micros();
+    }
+    const uint32_t workStartUs = platform::micros();
 
     // Scheduler gates loop callbacks by `enabled()` — disabled modules don't tick.
     // System modules that need to keep running regardless (HttpServer, Network,
@@ -88,11 +88,13 @@ void Scheduler::tick() {
     auto shouldRun = [](MoonModule* m) {
         return !m->respectsEnabled() || m->enabled();
     };
-    for (uint8_t i = 0; i < moduleCount_; i++) {
-        if (!shouldRun(modules_[i])) continue;
-        uint32_t modStart = platform::micros();
-        modules_[i]->loop();
-        modules_[i]->addAccumUs(platform::micros() - modStart);
+    if (renderedFrame) {
+        for (uint8_t i = 0; i < moduleCount_; i++) {
+            if (!shouldRun(modules_[i])) continue;
+            uint32_t modStart = platform::micros();
+            modules_[i]->loop();
+            modules_[i]->addAccumUs(platform::micros() - modStart);
+        }
     }
 
     if (now - lastLoop20ms_ >= 20) {
@@ -122,7 +124,7 @@ void Scheduler::tick() {
         if (loop1sCursor_ >= moduleCount_) loop1sSweepActive_ = false;
     }
 
-    frameCount_++;
+    if (renderedFrame) frameCount_++;
 
     // Every 1 second: publish per-module timing. Do this before closing the
     // scheduler timing window so the publish walk itself is counted in maxWorkUs.
@@ -139,21 +141,24 @@ void Scheduler::tick() {
     const uint32_t workElapsedUs = tickEndUs - workStartUs;
     tickAccumUs_ += frameElapsedUs;
     workAccumUs_ += workElapsedUs;
+    tickSampleCount_++;
     if (workElapsedUs > maxWorkAccumUs_) maxWorkAccumUs_ = workElapsedUs;
     if (frameElapsedUs > maxFrameAccumUs_) maxFrameAccumUs_ = frameElapsedUs;
 
     // Every 1 second: compute scheduler averages/maxima.
     if (publishWindow) {
-        tickTimeUs_ = frameCount_ > 0 ? tickAccumUs_ / frameCount_ : 0;
-        workTimeUs_ = frameCount_ > 0 ? workAccumUs_ / frameCount_ : 0;
+        tickTimeUs_ = tickSampleCount_ > 0 ? tickAccumUs_ / tickSampleCount_ : 0;
+        workTimeUs_ = tickSampleCount_ > 0 ? workAccumUs_ / tickSampleCount_ : 0;
         maxWorkTimeUs_ = maxWorkAccumUs_;
         maxFrameTimeUs_ = maxFrameAccumUs_;
+        fps_ = frameCount_;
 
         tickAccumUs_ = 0;
         workAccumUs_ = 0;
         maxWorkAccumUs_ = 0;
         maxFrameAccumUs_ = 0;
         frameCount_ = 0;
+        tickSampleCount_ = 0;
         lastTimingUpdate_ = platform::millis();
     }
 }

--- a/src/core/Scheduler.cpp
+++ b/src/core/Scheduler.cpp
@@ -63,8 +63,22 @@ void Scheduler::setup() {
 }
 
 void Scheduler::tick() {
-    uint32_t now = platform::millis();
     uint32_t tickStart = platform::micros();
+
+    if (lastFrameStartUs_ != 0) {
+        const uint32_t targetFrameUs = 1000000u / targetFps_;
+        const uint32_t dueUs = lastFrameStartUs_ + targetFrameUs;
+        for (;;) {
+            const uint32_t nowUs = platform::micros();
+            if (static_cast<int32_t>(nowUs - dueUs) >= 0) break;
+            const uint32_t remainingUs = dueUs - nowUs;
+            if (remainingUs >= 2000) platform::delayMs(remainingUs / 1000);
+            else platform::yield();
+        }
+    }
+    lastFrameStartUs_ = platform::micros();
+    const uint32_t workStartUs = lastFrameStartUs_;
+    uint32_t now = platform::millis();
 
     // Scheduler gates loop callbacks by `enabled()` — disabled modules don't tick.
     // System modules that need to keep running regardless (HttpServer, Network,
@@ -91,30 +105,56 @@ void Scheduler::tick() {
         }
     }
 
-    if (now - lastLoop1s_ >= 1000) {
+    if (!loop1sSweepActive_ && now - lastLoop1s_ >= 1000) {
         lastLoop1s_ = now;
-        for (uint8_t i = 0; i < moduleCount_; i++) {
-            if (!shouldRun(modules_[i])) continue;
+        loop1sSweepActive_ = true;
+        loop1sCursor_ = 0;
+    }
+    if (loop1sSweepActive_) {
+        while (loop1sCursor_ < moduleCount_) {
+            MoonModule* mod = modules_[loop1sCursor_++];
+            if (!shouldRun(mod)) continue;
             uint32_t modStart = platform::micros();
-            modules_[i]->loop1s();
-            modules_[i]->addAccumUs(platform::micros() - modStart);
+            mod->loop1s();
+            mod->addAccumUs(platform::micros() - modStart);
+            break;
         }
+        if (loop1sCursor_ >= moduleCount_) loop1sSweepActive_ = false;
     }
 
-    tickAccumUs_ += platform::micros() - tickStart;
     frameCount_++;
 
-    // Every 1 second: compute averages, recurse into children
-    if (now - lastTimingUpdate_ >= 1000) {
-        tickTimeUs_ = frameCount_ > 0 ? tickAccumUs_ / frameCount_ : 0;
-
+    // Every 1 second: publish per-module timing. Do this before closing the
+    // scheduler timing window so the publish walk itself is counted in maxWorkUs.
+    const uint32_t timingNow = platform::millis();
+    const bool publishWindow = timingNow - lastTimingUpdate_ >= 1000;
+    if (publishWindow) {
         for (uint8_t i = 0; i < moduleCount_; i++) {
             modules_[i]->publishTiming(frameCount_);
         }
+    }
+
+    const uint32_t tickEndUs = platform::micros();
+    const uint32_t frameElapsedUs = tickEndUs - tickStart;
+    const uint32_t workElapsedUs = tickEndUs - workStartUs;
+    tickAccumUs_ += frameElapsedUs;
+    workAccumUs_ += workElapsedUs;
+    if (workElapsedUs > maxWorkAccumUs_) maxWorkAccumUs_ = workElapsedUs;
+    if (frameElapsedUs > maxFrameAccumUs_) maxFrameAccumUs_ = frameElapsedUs;
+
+    // Every 1 second: compute scheduler averages/maxima.
+    if (publishWindow) {
+        tickTimeUs_ = frameCount_ > 0 ? tickAccumUs_ / frameCount_ : 0;
+        workTimeUs_ = frameCount_ > 0 ? workAccumUs_ / frameCount_ : 0;
+        maxWorkTimeUs_ = maxWorkAccumUs_;
+        maxFrameTimeUs_ = maxFrameAccumUs_;
 
         tickAccumUs_ = 0;
+        workAccumUs_ = 0;
+        maxWorkAccumUs_ = 0;
+        maxFrameAccumUs_ = 0;
         frameCount_ = 0;
-        lastTimingUpdate_ = now;
+        lastTimingUpdate_ = platform::millis();
     }
 }
 

--- a/src/core/Scheduler.h
+++ b/src/core/Scheduler.h
@@ -18,10 +18,9 @@ namespace mm {
 /// time and publishes each module's loop time.
 ///
 /// **Loop rates:** three cadences cover every module. `loop()` is the hot path for
-/// effects and drivers, called every iteration — the Scheduler handles pacing (yielding
-/// to other tasks between iterations via `taskYIELD()` on ESP32, an optional sleep on
-/// desktop). `loop20ms()` runs every ~20 ms for UI updates, control reads, and network
-/// polling. `loop1s()` runs every ~1 second for diagnostics, reconnects, and
+/// effects and drivers, called when the elapsed-time FPS gate opens. `loop20ms()` runs
+/// every ~20 ms for UI updates, control reads, and network polling. `loop1s()` runs every
+/// ~1 second for diagnostics, reconnects, and
 /// housekeeping. Not every module needs `loop()`: system modules (HTTP, WiFi) use
 /// `loop20ms()` or `loop1s()` only.
 ///
@@ -79,7 +78,7 @@ public:
     uint32_t workTimeUs() const { return workTimeUs_; }
     uint32_t maxWorkTimeUs() const { return maxWorkTimeUs_; }
     uint32_t maxFrameTimeUs() const { return maxFrameTimeUs_; }
-    uint32_t fps() const { return tickTimeUs_ > 0 ? 1000000 / tickTimeUs_ : 0; }
+    uint32_t fps() const { return fps_; }
     uint8_t moduleCount() const { return moduleCount_; }
     MoonModule* module(uint8_t i) const { return i < moduleCount_ ? modules_[i] : nullptr; }
 
@@ -147,7 +146,9 @@ private:
     uint32_t maxFrameTimeUs_ = 0;
     uint32_t maxWorkAccumUs_ = 0;
     uint32_t maxFrameAccumUs_ = 0;
-    uint32_t frameCount_ = 0;        // frames in current 1-second window (for averaging)
+    uint32_t frameCount_ = 0;        // rendered frames in current 1-second window
+    uint32_t tickSampleCount_ = 0;   // scheduler ticks sampled in current 1-second window
+    uint32_t fps_ = 0;               // rendered frames in the last completed 1-second window
     uint32_t lastTimingUpdate_ = 0;   // 1-second window start
     uint32_t lastFrameStartUs_ = 0;
     uint8_t loop1sCursor_ = 0;

--- a/src/core/Scheduler.h
+++ b/src/core/Scheduler.h
@@ -65,10 +65,20 @@ public:
     void tick();
     void teardown();
 
+    void setTargetFps(uint8_t fps) {
+        if (fps < 10) fps = 10;
+        if (fps > 120) fps = 120;
+        targetFps_ = fps;
+    }
+    uint8_t targetFps() const { return targetFps_; }
+
     uint32_t elapsed() const;
     void buildState();
 
     uint32_t tickTimeUs() const { return tickTimeUs_; }
+    uint32_t workTimeUs() const { return workTimeUs_; }
+    uint32_t maxWorkTimeUs() const { return maxWorkTimeUs_; }
+    uint32_t maxFrameTimeUs() const { return maxFrameTimeUs_; }
     uint32_t fps() const { return tickTimeUs_ > 0 ? 1000000 / tickTimeUs_ : 0; }
     uint8_t moduleCount() const { return moduleCount_; }
     MoonModule* module(uint8_t i) const { return i < moduleCount_ ? modules_[i] : nullptr; }
@@ -131,8 +141,18 @@ private:
     uint32_t lastLoop1s_ = 0;
     uint32_t tickTimeUs_ = 0;
     uint32_t tickAccumUs_ = 0;
+    uint32_t workTimeUs_ = 0;
+    uint32_t workAccumUs_ = 0;
+    uint32_t maxWorkTimeUs_ = 0;
+    uint32_t maxFrameTimeUs_ = 0;
+    uint32_t maxWorkAccumUs_ = 0;
+    uint32_t maxFrameAccumUs_ = 0;
     uint32_t frameCount_ = 0;        // frames in current 1-second window (for averaging)
     uint32_t lastTimingUpdate_ = 0;   // 1-second window start
+    uint32_t lastFrameStartUs_ = 0;
+    uint8_t loop1sCursor_ = 0;
+    uint8_t targetFps_ = 60;
+    bool loop1sSweepActive_ = false;
 };
 
 // --- Drivers master-state reads, shared by every consumer that mirrors the light state (the WLED

--- a/src/core/SystemModule.h
+++ b/src/core/SystemModule.h
@@ -106,6 +106,8 @@ public:
             (void)platform::coprocessorWifi();   // prime the static (the control points at it)
         }
 
+        if (scheduler_) scheduler_->setTargetFps(fpsCap_);
+
         if (chipFlashVal_ > 0) {
             std::snprintf(flashStr_, sizeof(flashStr_), "%uMB",
                           static_cast<unsigned>(chipFlashVal_ / (1024 * 1024)));
@@ -142,6 +144,7 @@ public:
         // Dynamic (updated every second)
         controls_.addReadOnly("uptime", uptimeStr_, sizeof(uptimeStr_));
         controls_.addReadOnly("fps", fpsStr_, sizeof(fpsStr_));
+        controls_.addUint8("fpsCap", fpsCap_, 10, 120);
         controls_.addReadOnly("tickTimeUs", tickStr_, sizeof(tickStr_));
         if (totalInternalVal_ > 0) {
             controls_.addProgress("heap", heapUsedVal_, totalInternalVal_);
@@ -193,6 +196,12 @@ public:
         MoonModule::onBuildControls();
     }
 
+    void onUpdate(const char* name) override {
+        if (std::strcmp(name, "fpsCap") == 0 && scheduler_) {
+            scheduler_->setTargetFps(fpsCap_);
+        }
+    }
+
     void loop1s() override {
         // deviceName is the single network identity (mDNS <name>.local, SoftAP SSID,
         // DHCP hostname all derive from it), so it must stay a valid hostname whatever
@@ -218,6 +227,8 @@ public:
 
         uint32_t fps = scheduler_ ? scheduler_->fps() : 0;
         std::snprintf(fpsStr_, sizeof(fpsStr_), "%u", static_cast<unsigned>(fps));
+
+        if (scheduler_) scheduler_->setTargetFps(fpsCap_);
 
         uint32_t tickUs = scheduler_ ? scheduler_->tickTimeUs() : 0;
         std::snprintf(tickStr_, sizeof(tickStr_), "%u", static_cast<unsigned>(tickUs));
@@ -290,6 +301,7 @@ private:
     // entry ("Olimex ESP32-Gateway Rev G" = 26) with headroom; the Improv RPC handler
     // caps str_len against this size dynamically.
     char deviceModel_[32] = {};
+    uint8_t fpsCap_ = 60;
 
     // Dynamic (updated in loop1s)
     char uptimeStr_[16] = {};

--- a/src/light/drivers/Correction.h
+++ b/src/light/drivers/Correction.h
@@ -7,19 +7,50 @@ namespace mm {
 // Light preset = the physical wire format a driver emits: channel order plus
 // whether the light has a white channel. The order in this enum is index-aligned
 // with kLightPresetOptions below (the Select control's option list), so the
-// control's uint8 value casts straight to LightPreset.
-enum class LightPreset : uint8_t { RGB, RBG, GRB, GBR, BRG, BGR, RGBW, GRBW };
+// control's uint8 value casts straight to LightPreset. RGBW includes every
+// 4-channel permutation so controllers can use white-first RGBW pixels
+// without a driver-specific swap.
+enum class LightPreset : uint8_t {
+    RGB, RBG, GRB, GBR, BRG, BGR,
+    RGBW, RBGW, GRBW, GBRW, BRGW, BGRW,
+    RWGB, RWBG, GWRB, GWBR, BWRG, BWGR,
+    WRGB, WRBG, WGRB, WGBR, WBRG, WBGR,
+};
 
 inline constexpr const char* kLightPresetOptions[] =
-    {"RGB", "RBG", "GRB", "GBR", "BRG", "BGR", "RGBW", "GRBW"};
+    {"RGB", "RBG", "GRB", "GBR", "BRG", "BGR",
+     "RGBW", "RBGW", "GRBW", "GBRW", "BRGW", "BGRW",
+     "RWGB", "RWBG", "GWRB", "GWBR", "BWRG", "BWGR",
+     "WRGB", "WRBG", "WGRB", "WGBR", "WBRG", "WBGR"};
 inline constexpr uint8_t kLightPresetCount =
     sizeof(kLightPresetOptions) / sizeof(kLightPresetOptions[0]);
 
+inline constexpr uint8_t kLightPresetChannels[kLightPresetCount] = {
+    3, 3, 3, 3, 3, 3,
+    4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4,
+};
+
+// Source-channel indices per output byte. Source is logical RGB plus W at index
+// 3 for RGBW presets. W is explicit when the layer carries 4 channels; otherwise
+// it is derived as min(R,G,B) so RGB-only effects still light RGBW strips.
+inline constexpr uint8_t kLightPresetOrder[kLightPresetCount][4] = {
+    {0, 1, 2, 3}, {0, 2, 1, 3}, {1, 0, 2, 3},
+    {1, 2, 0, 3}, {2, 0, 1, 3}, {2, 1, 0, 3},
+    {0, 1, 2, 3}, {0, 2, 1, 3}, {1, 0, 2, 3},
+    {1, 2, 0, 3}, {2, 0, 1, 3}, {2, 1, 0, 3},
+    {0, 3, 1, 2}, {0, 3, 2, 1}, {1, 3, 0, 2},
+    {1, 3, 2, 0}, {2, 3, 0, 1}, {2, 3, 1, 0},
+    {3, 0, 1, 2}, {3, 0, 2, 1}, {3, 1, 0, 2},
+    {3, 1, 2, 0}, {3, 2, 0, 1}, {3, 2, 1, 0},
+};
+
 // Output correction applied per-light by each physical driver as it reads the
 // shared source buffer: brightness scale, channel reorder, and (for RGBW presets)
-// white derivation. The Drivers container owns one Correction instance, rebuilds
-// it on a brightness / light-preset change (cheap, cold path), and hands a const
-// pointer to each driver child. apply() is the hot-path per-light transform.
+// explicit/derived white. The Drivers container owns one Correction instance,
+// rebuilds it on a brightness / light-preset change (cheap, cold path), and hands
+// a const pointer to each driver child. apply() is the hot-path per-light transform.
 //
 // Today only NetworkSendDriver consumes it; future LED drivers (WS2812 via RMT,
 // APA102 via SPI) apply the same correction before their protocol encode.
@@ -32,7 +63,7 @@ struct Correction {
     uint8_t briLut[256] = {};       // briLut[v] = (v * brightness) / 255 (scale8)
     uint8_t order[4] = {0, 1, 2, 3}; // source-channel index for each output position
     uint8_t outChannels = 3;        // 3 (RGB family) or 4 (RGBW family)
-    bool    deriveWhite = false;    // RGBW presets: W = min(r, g, b)
+    bool    deriveWhite = false;    // RGBW presets: W = src[3] when present, else min(r,g,b)
 
     // Cold path: recompute the LUT + preset-derived layout. Called from Drivers on
     // setup, on a structural rebuild, and on a brightness / light-preset onUpdate.
@@ -40,37 +71,25 @@ struct Correction {
         for (int v = 0; v < 256; v++) {
             briLut[v] = static_cast<uint8_t>((v * brightness) / 255);
         }
-        // Clamp out-of-range presets (corrupt persisted lightPreset cast to
-        // the enum) to RGB BEFORE the switch — that way the switch stays
-        // exhaustive, the compiler warns on a missing enumerator if we add
-        // one without handling it (-Wswitch), and apply() always reads
-        // initialised order/outChannels/deriveWhite.
-        if (static_cast<uint8_t>(preset) >= kLightPresetCount) {
-            preset = LightPreset::RGB;
-        }
-        // order[] holds the SOURCE channel index to place at each OUTPUT position.
-        // Source is always RGB (indices 0=R, 1=G, 2=B), white at index 3.
-        switch (preset) {
-            case LightPreset::RGB:  order[0]=0; order[1]=1; order[2]=2; outChannels=3; deriveWhite=false; break;
-            case LightPreset::RBG:  order[0]=0; order[1]=2; order[2]=1; outChannels=3; deriveWhite=false; break;
-            case LightPreset::GRB:  order[0]=1; order[1]=0; order[2]=2; outChannels=3; deriveWhite=false; break;
-            case LightPreset::GBR:  order[0]=1; order[1]=2; order[2]=0; outChannels=3; deriveWhite=false; break;
-            case LightPreset::BRG:  order[0]=2; order[1]=0; order[2]=1; outChannels=3; deriveWhite=false; break;
-            case LightPreset::BGR:  order[0]=2; order[1]=1; order[2]=0; outChannels=3; deriveWhite=false; break;
-            case LightPreset::RGBW: order[0]=0; order[1]=1; order[2]=2; order[3]=3; outChannels=4; deriveWhite=true; break;
-            case LightPreset::GRBW: order[0]=1; order[1]=0; order[2]=2; order[3]=3; outChannels=4; deriveWhite=true; break;
-        }
+        uint8_t idx = static_cast<uint8_t>(preset);
+        if (idx >= kLightPresetCount) idx = static_cast<uint8_t>(LightPreset::RGB);
+        for (uint8_t i = 0; i < 4; i++) order[i] = kLightPresetOrder[idx][i];
+        outChannels = kLightPresetChannels[idx];
+        deriveWhite = outChannels == 4;
     }
 
-    // Hot path: transform one source light (3-channel RGB at `src`) into `out`
-    // (`outChannels` bytes). Brightness via LUT, then reorder, then white. No
-    // allocation, integer-only.
-    inline void apply(const uint8_t* src, uint8_t* out) const {
+    // Hot path: transform one source light into `out` (`outChannels` bytes).
+    // Brightness via LUT, then reorder, then white. RGBW layers provide an
+    // explicit W byte; RGB layers keep the legacy derived-white fallback.
+    // No allocation, integer-only.
+    inline void apply(const uint8_t* src, uint8_t* out, uint8_t srcChannels = 3) const {
         const uint8_t r = briLut[src[0]];
         const uint8_t g = briLut[src[1]];
         const uint8_t b = briLut[src[2]];
         if (deriveWhite) {
-            const uint8_t w = r < g ? (r < b ? r : b) : (g < b ? g : b);  // min(r,g,b)
+            const uint8_t w = srcChannels >= 4
+                ? briLut[src[3]]
+                : (r < g ? (r < b ? r : b) : (g < b ? g : b));  // min(r,g,b)
             const uint8_t v[4] = {r, g, b, w};
             for (uint8_t i = 0; i < outChannels; i++) out[i] = v[order[i]];
         } else {

--- a/src/light/drivers/Drivers.h
+++ b/src/light/drivers/Drivers.h
@@ -9,6 +9,7 @@
 #include "light/drivers/Correction.h"
 #include "light/Palette.h"   // the global active palette + its select control
 #include "core/LightSummary.h"   // the POD published for the domain-neutral WLED/MQTT consumers
+#include "core/FilesystemModule.h" // noteDirty for one-time legacy setting migrations
 #include "platform/platform.h"
 
 #include <cstring>  // std::strcmp in onUpdate
@@ -108,9 +109,9 @@ public:
     /// lights-control surface). Default on so a freshly-flashed board lights up.
     bool on = true;
     /// Physical wire format: channel order and whether the light is RGBW (index into
-    /// `kLightPresetOptions`; options `RGB`, `RBG`, `GRB`, `GBR`, `BRG`, `BGR`, `RGBW`,
-    /// `GRBW`). RGBW presets make each driver emit 4 channels per light with white
-    /// derived as `min(R,G,B)` from the (brightness-scaled) RGB.
+    /// `kLightPresetOptions`; RGB orders plus every RGBW byte permutation). RGBW
+    /// presets make each driver emit 4 channels per light with white derived as
+    /// `min(R,G,B)` from the (brightness-scaled) RGB.
     ///
     /// GRB (index 2) is the wire order of WS2812/SK6812 strips — the common case, so a
     /// freshly-flashed board with a strip attached shows correct colours out of the box.
@@ -124,6 +125,16 @@ public:
     /// changing this recolours every such effect live. The select index expands the chosen
     /// gradient into the active 16-entry palette on `onUpdate` (cheap, off the hot path).
     uint8_t palette = 0;
+
+    /// Hidden migration marker for the physical-light preset schema. Older builds
+    /// had only RGB plus two RGBW presets, so a saved numeric index can mean the
+    /// wrong wire byte order after the expanded RGBW preset list lands.
+    uint8_t lightPresetSchema = 0;
+
+    void setLegacyLightDefaults(uint8_t preset, uint8_t brightnessCap = 255) {
+        legacyLightPresetTarget_ = preset;
+        legacyBrightnessCap_ = brightnessCap;
+    }
 
     // Two ways to wire the source Layer:
     //  - setLayers(Layers*): bind the container; layer_ is re-resolved from
@@ -149,6 +160,8 @@ public:
         controls_.addBool("on", on);   // master power — first so it renders at the top of the card
         controls_.addUint8("brightness", brightness, 0, 255);
         controls_.addSelect("lightPreset", lightPreset, kLightPresetOptions, kLightPresetCount);
+        controls_.addUint8("lightPresetSchema", lightPresetSchema, 0, kLightPresetSchemaVersion);
+        controls_.setHidden(controls_.count() - 1, true);
         controls_.addPalette("palette", palette, mm::paletteOptions, mm::palettes::kCount);
         MoonModule::onBuildControls();  // cascade to driver children
     }
@@ -176,6 +189,7 @@ public:
     }
 
     void setup() override {
+        migrateLegacyLightDefaults();
         correction_.rebuild(effectiveBrightness(), static_cast<LightPreset>(lightPreset));
         Palettes::setActive(palette);   // seed the global active palette from the persisted index
         MoonModule::setup();
@@ -291,6 +305,33 @@ private:
     // stops being read; only one Drivers exists in the pinned tree, so no re-election dance is needed.
     LightSummary summary_;
     inline static Drivers* active_ = nullptr;
+
+    static constexpr uint8_t kLightPresetSchemaVersion = 1;
+    static constexpr uint8_t kNoLegacyLightPresetTarget = 255;
+    uint8_t legacyLightPresetTarget_ = kNoLegacyLightPresetTarget;
+    uint8_t legacyBrightnessCap_ = 255;
+
+    void migrateLegacyLightDefaults() {
+        if (lightPresetSchema >= kLightPresetSchemaVersion) return;
+
+        bool changed = false;
+        if (legacyLightPresetTarget_ < kLightPresetCount &&
+            lightPreset != legacyLightPresetTarget_) {
+            lightPreset = legacyLightPresetTarget_;
+            changed = true;
+        }
+        if (brightness > legacyBrightnessCap_) {
+            brightness = legacyBrightnessCap_;
+            changed = true;
+        }
+        lightPresetSchema = kLightPresetSchemaVersion;
+        changed = true;
+
+        if (changed) {
+            markDirty();
+            FilesystemModule::noteDirty();
+        }
+    }
 
     void passBufferToDrivers() {
         // No active Layer (e.g. the last Layer was just deleted): clear every

--- a/src/light/drivers/HueDriver.h
+++ b/src/light/drivers/HueDriver.h
@@ -641,7 +641,7 @@ private:
             // brightness slider and a swapped colour order reach Hue too — same as the physical
             // drivers. apply() writes outChannels bytes; we read the first three (RGB) for HSV.
             uint8_t rgb[4] = { px[0], px[1], px[2], 0 };
-            if (correction_) correction_->apply(px, rgb);
+            if (correction_) correction_->apply(px, rgb, cpl);
             char body[80];
             if (diffAndFormat(li, rgb[0], rgb[1], rgb[2], body, sizeof(body))) {
                 char host[16]; bridgeStr(host);

--- a/src/light/drivers/LedDriverConfig.h
+++ b/src/light/drivers/LedDriverConfig.h
@@ -4,6 +4,12 @@
 
 namespace mm {
 
+inline constexpr uint8_t kLedChipsetWs2812b = 0;
+inline constexpr uint8_t kLedChipsetSk6812Rgbw = 1;
+inline constexpr const char* kLedChipsetOptions[] = {"WS2812B", "SK6812 RGBW"};
+inline constexpr uint8_t kLedChipsetCount =
+    sizeof(kLedChipsetOptions) / sizeof(kLedChipsetOptions[0]);
+
 // Wire timing for a clockless addressable-LED chipset (WS2812B by default).
 // Pure data — no platform include — so the encoder that reads it is host-testable.
 //
@@ -18,6 +24,26 @@ struct LedDriverConfig {
     uint32_t period_ns = 1250;   // full bit cell (t?h + the trailing LOW)
     uint32_t reset_us  = 300;    // idle-LOW latch between frames (>= 300 us, current silicon)
     bool     invert    = false;  // flip output polarity, for inverting level-shifters
+
+    void applyChipset(uint8_t chipset) {
+        const bool keepInvert = invert;
+        switch (chipset) {
+            case kLedChipsetSk6812Rgbw:
+                t0h_ns = 300;
+                t1h_ns = 600;
+                period_ns = 1250;
+                reset_us = 300;
+                break;
+            case kLedChipsetWs2812b:
+            default:
+                t0h_ns = 350;
+                t1h_ns = 700;
+                period_ns = 1250;
+                reset_us = 300;
+                break;
+        }
+        invert = keepInvert;
+    }
 };
 
 } // namespace mm

--- a/src/light/drivers/NetworkSendDriver.h
+++ b/src/light/drivers/NetworkSendDriver.h
@@ -165,7 +165,7 @@ public:
             uint8_t* dst = corrected_.data();
             for (nrOfLightsType i = 0; i < nLights; i++) {
                 // Read the windowed light (slice starts at winStart); pack densely.
-                correction_->apply(src + (winStart + i) * srcCh, dst + i * outCh);
+                correction_->apply(src + (winStart + i) * srcCh, dst + i * outCh, srcCh);
             }
             data = dst;
             totalBytes = static_cast<size_t>(nLights) * outCh;

--- a/src/light/drivers/ParallelLedDriver.h
+++ b/src/light/drivers/ParallelLedDriver.h
@@ -176,7 +176,7 @@ public:
                 // winStart_ shifts this driver's whole slice; laneStart_ is the
                 // per-lane offset within it.
                 correction_->apply(src + (winStart_ + laneStart_[lane] + row) * srcCh,
-                                   wire + lane * 4);
+                                   wire + lane * 4, srcCh);
             }
             encodeWs2812LcdSlots(wire, mask, outCh, out);
             out += static_cast<size_t>(outCh) * 8 * 3;

--- a/src/light/drivers/RmtLedDriver.h
+++ b/src/light/drivers/RmtLedDriver.h
@@ -108,6 +108,8 @@ public:
         addWindowControls();   // start / count — the slice of the shared buffer this driver outputs
         controls_.addText("pins", pins, sizeof(pins));
         controls_.addText("ledsPerPin", ledsPerPin, sizeof(ledsPerPin));
+        controls_.addReadOnly("backend", backend_, sizeof(backend_));
+        controls_.addReadOnly("frameStats", frameStats_, sizeof(frameStats_));
         controls_.addBool("loopbackTest", loopbackTest);
         // loopbackTxPin / loopbackRxPin are always bound (so persistence can load
         // them any time) but only shown while the test mode is on — same always-
@@ -233,6 +235,13 @@ public:
         if (n == 0 || outCh == 0 || pinCount_ == 0
             || !symbols_ || symbolCap_ < symbolsFor(n, outCh)) return;
 
+        for (uint8_t i = 0; i < pinCount_; i++) {
+            if (platform::rmtWs2812Busy(rmt_[i])) {
+                recordSkippedFrame();
+                return;
+            }
+        }
+
         // Fused single pass: correct one light into wire bytes, encode those
         // bytes straight into the symbol buffer. No second sweep over encoded
         // data, no per-light heap.
@@ -262,20 +271,35 @@ public:
         // resize lands a tick before the config re-parse) n can be below Σ pinCounts_ — cap each
         // pin at the encoded boundary so it never clocks out stale symbols past what we wrote.
         const size_t wordsPerLight = static_cast<size_t>(outCh) * 8;
-        bool started[kMaxPins] = {};
         for (uint8_t i = 0; i < pinCount_; i++) {
             const nrOfLightsType pinStart = static_cast<nrOfLightsType>(pinOffsets_[i] / wordsPerLight);
             if (pinStart >= n) break;  // contiguous: this pin and all later ones are past the encoded lights
             const nrOfLightsType pinLights =
                 (pinStart + pinCounts_[i] > n) ? static_cast<nrOfLightsType>(n - pinStart) : pinCounts_[i];
             if (pinLights == 0) continue;
-            started[i] = platform::rmtWs2812Transmit(rmt_[i], symbols_ + pinOffsets_[i],
-                                        static_cast<size_t>(pinLights) * wordsPerLight);
+            if (!platform::rmtWs2812Transmit(rmt_[i], symbols_ + pinOffsets_[i],
+                                             static_cast<size_t>(pinLights) * wordsPerLight)) {
+                recordSkippedFrame();
+            }
         }
-        for (uint8_t i = 0; i < pinCount_; i++) {
-            if (started[i]) platform::rmtWs2812Wait(rmt_[i], 1000 /* ms */);
+    }
+
+    void loop1s() override {
+        const uint32_t skipped = skippedFrames_;
+        skippedFrames_ = 0;
+        std::snprintf(frameStats_, sizeof(frameStats_), "skip %lu/s total %lu",
+                      static_cast<unsigned long>(skipped),
+                      static_cast<unsigned long>(skippedTotal_));
+        if (!configErr_ && !configWarn_) {
+            if (skipped > 0) {
+                std::snprintf(skipStatus_, sizeof(skipStatus_), "RMT skipped %lu frames/s",
+                              static_cast<unsigned long>(skipped));
+                setStatus(skipStatus_, Severity::Warning);
+            } else if (status() == skipStatus_) {
+                clearStatus();
+            }
         }
-        if (cfg_.reset_us) platform::delayUs(cfg_.reset_us);
+        MoonModule::loop1s();
     }
 
     /// Test-only accessors. symbolBuffer/symbolCapacity mirror ArtNet's
@@ -301,6 +325,7 @@ private:
     const Correction* correction_ = nullptr;
 
     LedDriverConfig cfg_;
+    char backend_[16] = "none";
     platform::RmtWs2812Handle rmt_[kMaxPins];
     uint16_t       pinList_[kMaxPins] = {};    // parsed pins, list order
     nrOfLightsType pinCounts_[kMaxPins] = {};  // lights per pin (slice lengths)
@@ -312,6 +337,10 @@ private:
     bool inited_ = false;                      // all-or-nothing across the pins
     uint32_t* symbols_ = nullptr;   // owned; one word per WS2812 data bit
     size_t symbolCap_ = 0;          // words allocated
+    uint32_t skippedFrames_ = 0;
+    uint32_t skippedTotal_ = 0;
+    char frameStats_[32] = "skip 0/s total 0";
+    char skipStatus_[40] = {};
 
     // The parse-error literal currently shown in the status slot (nullptr when
     // configErr_, failBuf_, kFailBufLen and the clearConfigErr/clearFailBuf/
@@ -319,6 +348,15 @@ private:
     // the LCD and Parlio drivers). The on-demand FAIL string (failBuf_) is only
     // formatted when a loopback or channel init FAILs; PASS/jumper/unsupported use
     // flash literals.
+
+    void setBackend(const char* value) {
+        std::snprintf(backend_, sizeof(backend_), "%s", value ? value : "none");
+    }
+
+    void recordSkippedFrame() {
+        skippedFrames_++;
+        skippedTotal_++;
+    }
 
     // The chip's TX-channel cap caps the pin list; on targets without RMT
     // (desktop, where the constant is 0) fall back to kMaxPins so the parsing
@@ -524,6 +562,7 @@ private:
             return;
         }
         inited_ = true;
+        setBackend(platform::rmtWs2812Backend(rmt_[0]));
         // A prior init failure recovered (e.g. a pin fixed) — drop the stale error.
         if (failBuf_ && status() == failBuf_) clearFailBuf();
         if (status() == kInitFailMsg) clearStatus();
@@ -537,6 +576,7 @@ private:
         for (uint8_t i = 0; i < kMaxPins; i++) {
             if (rmt_[i].impl) platform::rmtWs2812Deinit(rmt_[i]);
         }
+        setBackend("none");
         inited_ = false;
     }
 };

--- a/src/light/drivers/RmtLedDriver.h
+++ b/src/light/drivers/RmtLedDriver.h
@@ -66,6 +66,16 @@ public:
     /// not this safety cap.
     char ledsPerPin[48] = "";
 
+    /// LED timing profile. Generic boards default to WS2812B; RGBW fixtures can use
+    /// SK6812 RGBW timing so their 4-channel pixels decode with more margin.
+    uint8_t chipset = kLedChipsetWs2812b;
+
+    void setChipset(uint8_t value) {
+        if (value >= kLedChipsetCount) value = kLedChipsetWs2812b;
+        chipset = value;
+        cfg_.applyChipset(chipset);
+    }
+
     /// On-device loopback self-test — RMT is a transceiver, so the driver verifies its own output
     /// on real silicon (replaces the old standalone test firmware). Tick to run a one-shot RMT
     /// TX→RX round-trip: jumper the first pin (TX) to `loopbackRxPin`, it transmits a known WS2812
@@ -92,8 +102,9 @@ public:
     /// and still clocked back to back; the S3/P4 capture the full frame via DMA.
     bool     loopbackFrame = false;
 
-    // 40 MHz RMT tick clock = 25 ns/tick: t0h 350ns→14, t1h 700ns→28, period
-    // 1250ns→50 ticks. The encoder converts ns→ticks via the granted resolution,
+    // 40 MHz RMT tick clock = 25 ns/tick; chipset timings convert from ns to ticks
+    // via the granted resolution, e.g. WS2812B t0h 350 ns -> 14 ticks and SK6812
+    // RGBW t0h 300 ns -> 12 ticks at the requested clock.
     // so this is the requested clock, not a hard-coded tick count.
     static constexpr uint32_t kResolutionHz = 40'000'000;
 
@@ -108,6 +119,7 @@ public:
         addWindowControls();   // start / count — the slice of the shared buffer this driver outputs
         controls_.addText("pins", pins, sizeof(pins));
         controls_.addText("ledsPerPin", ledsPerPin, sizeof(ledsPerPin));
+        controls_.addSelect("chipset", chipset, kLedChipsetOptions, kLedChipsetCount);
         controls_.addReadOnly("backend", backend_, sizeof(backend_));
         controls_.addReadOnly("frameStats", frameStats_, sizeof(frameStats_));
         controls_.addBool("loopbackTest", loopbackTest);
@@ -141,10 +153,12 @@ public:
     /// OFF clears the result.
     void onUpdate(const char* name) override {
         const bool isTestControl = std::strcmp(name, "loopbackTest") == 0;
+        const bool isChipsetControl = std::strcmp(name, "chipset") == 0;
         const bool isPinControl  = std::strcmp(name, "pins") == 0
                                 || std::strcmp(name, "loopbackTxPin") == 0
                                 || std::strcmp(name, "loopbackRxPin") == 0
                                 || std::strcmp(name, "loopbackFrame") == 0;
+        if (isChipsetControl) setChipset(chipset);
         if (isTestControl && !loopbackTest) {
             // Toggling the test off clears the loopback verdict, then re-derives
             // the real driver status — a config/init error must survive (a blind
@@ -153,7 +167,7 @@ public:
             clearStatus();
             parseConfig();
             reinit();
-        } else if (loopbackTest && (isTestControl || isPinControl)) {
+        } else if (loopbackTest && (isTestControl || isPinControl || isChipsetControl)) {
             // A `pins` edit changes pinList_/pinCount_, but onUpdate runs BEFORE the
             // onBuildState() sweep re-parses (and loopbackRxPin/loopbackFrame don't
             // trigger that sweep at all), so refresh here before testing — otherwise
@@ -175,7 +189,7 @@ public:
     /// reinit() (a rebuild) calls — so a rebuild freed the buffer loop() needs.
     /// Keeping the two apart makes that mistake impossible here and lets the host
     /// unit test (unit_RmtLedDriver_lifecycle.cpp) pin it.
-    void setup() override { parseConfig(); reinit(); }
+    void setup() override { setChipset(chipset); parseConfig(); reinit(); }
     /// Release the RMT channels and free the symbol buffer, then clear the shared
     /// fail/config-error state (DriverBase::teardown()).
     void teardown() override {
@@ -214,9 +228,9 @@ public:
     }
 
     /// Per-tick output: fuse the correction and WS2812 symbol-encode in one pass
-    /// over this driver's window, then start every pin's transmit before waiting on
-    /// any, so the tick costs the longest strand rather than the sum. Inert off RMT
-    /// chips and idle until inited with a source buffer + correction.
+    /// over this driver's window, then start every pin's transmit and return. RMT/DMA
+    /// clocks the strip out in hardware; if the previous frame is still busy, this
+    /// tick is skipped so the render loop never blocks on the physical wire time.
     void loop() override {
         if constexpr (platform::rmtTxChannels == 0) return;  // inert off RMT chips
         if (!inited_ || !sourceBuffer_ || !sourceBuffer_->data() || !correction_) return;
@@ -254,17 +268,13 @@ public:
         uint8_t wire[4];
         for (nrOfLightsType i = 0; i < n; i++) {
             // Read the windowed light: this driver's slice starts at winStart_.
-            correction_->apply(src + (winStart_ + i) * srcCh, wire);
+            correction_->apply(src + (winStart_ + i) * srcCh, wire, srcCh);
             encodeWs2812Symbols(wire, outCh, t0h, t1h, period, symbols_ + s);
             s += static_cast<size_t>(outCh) * 8;
         }
-        // Start every pin's slice before waiting on any — the channels clock out
-        // concurrently, so the tick is charged the longest strand, not the sum.
-        // The shared reset gap (the WS2812 latch) runs once, after the last wait.
-        // Wait ONLY on channels whose transmit started: a failed transmit gives
-        // no done-callback, so waiting on it would block the full 1000 ms timeout
-        // and a single bad pin would stall the tick (the same guard the LCD /
-        // Parlio loops use, here per channel).
+        // Start every pin's slice back-to-back. The channels clock out concurrently
+        // and completion is tracked by the platform callback; the next loop() skips
+        // while any channel is busy, preserving the symbol buffer for DMA/RMT.
         // Transmit only up to the n lights actually encoded this frame: pins are laid out
         // contiguously from light 0, so pin i covers lights [pinStart, pinStart+pinCounts_[i]).
         // Normally Σ pinCounts_ == n, but if the buffer shrank since the last parseConfig (a grid
@@ -493,9 +503,11 @@ private:
             const uint16_t lights = pinCounts_[0] > 0
                 ? static_cast<uint16_t>(pinCounts_[0]) : 64;
             const uint8_t ch = correction_ ? correction_->outChannels : 3;
-            r = platform::rmtWs2812LoopbackFrame(txPin, rxPin, lights, ch);
+            r = platform::rmtWs2812LoopbackFrame(txPin, rxPin, lights, ch,
+                                                 cfg_.t0h_ns, cfg_.t1h_ns, cfg_.period_ns);
         } else {
-            r = platform::rmtWs2812Loopback(txPin, rxPin);
+            r = platform::rmtWs2812Loopback(txPin, rxPin,
+                                            cfg_.t0h_ns, cfg_.t1h_ns, cfg_.period_ns);
         }
         reinit();
         if (!r.jumperDetected) {

--- a/src/platform/desktop/platform_desktop.cpp
+++ b/src/platform/desktop/platform_desktop.cpp
@@ -990,10 +990,12 @@ bool rmtWs2812Init(RmtWs2812Handle& /*h*/, uint8_t /*gpio*/, uint32_t /*resoluti
     return false;
 }
 uint32_t rmtWs2812Resolution(const RmtWs2812Handle& /*h*/) { return 0; }
+const char* rmtWs2812Backend(const RmtWs2812Handle& /*h*/) { return "none"; }
 bool rmtWs2812Transmit(RmtWs2812Handle& /*h*/, const uint32_t* /*symbols*/,
                        size_t /*symbolCount*/) {
     return false;
 }
+bool rmtWs2812Busy(const RmtWs2812Handle& /*h*/) { return false; }
 void rmtWs2812Wait(RmtWs2812Handle& /*h*/, uint32_t /*timeoutMs*/) {}
 void rmtWs2812Deinit(RmtWs2812Handle& /*h*/) {}
 size_t rmtWs2812RxCapture(uint8_t /*gpio*/, uint32_t /*resolutionHz*/,

--- a/src/platform/desktop/platform_desktop.cpp
+++ b/src/platform/desktop/platform_desktop.cpp
@@ -1003,11 +1003,15 @@ size_t rmtWs2812RxCapture(uint8_t /*gpio*/, uint32_t /*resolutionHz*/,
                           uint32_t /*timeoutMs*/) {
     return 0;
 }
-RmtLoopbackResult rmtWs2812Loopback(uint8_t /*txGpio*/, uint8_t /*rxGpio*/) {
+RmtLoopbackResult rmtWs2812Loopback(uint8_t /*txGpio*/, uint8_t /*rxGpio*/,
+                                    uint32_t /*t0hNs*/, uint32_t /*t1hNs*/,
+                                    uint32_t /*periodNs*/) {
     return {};   // not supported off ESP32
 }
 RmtLoopbackResult rmtWs2812LoopbackFrame(uint8_t /*txGpio*/, uint8_t /*rxGpio*/,
-                                         uint16_t /*lights*/, uint8_t /*channels*/) {
+                                         uint16_t /*lights*/, uint8_t /*channels*/,
+                                         uint32_t /*t0hNs*/, uint32_t /*t1hNs*/,
+                                         uint32_t /*periodNs*/) {
     return {};   // not supported off ESP32
 }
 

--- a/src/platform/esp32/platform_esp32_rmt.cpp
+++ b/src/platform/esp32/platform_esp32_rmt.cpp
@@ -61,6 +61,9 @@ bool rmtWs2812Init(RmtWs2812Handle& h, uint8_t gpio, uint32_t resolutionHz, bool
     if (!st) return false;
 
 #if SOC_RMT_SUPPORT_DMA
+    // On S3/P4, let DMA clock sustained WS2812 frames instead of relying on
+    // interrupt refills of the tiny RMT FIFO. A delayed refill under WiFi/HTTP
+    // load can stretch a bit cell and show up as random flashing pixels.
     auto makeCfg = [&](bool withDma) {
         rmt_tx_channel_config_t txCfg = {};
         txCfg.gpio_num = static_cast<gpio_num_t>(gpio);
@@ -88,11 +91,8 @@ bool rmtWs2812Init(RmtWs2812Handle& h, uint8_t gpio, uint32_t resolutionHz, bool
     txCfg.gpio_num = static_cast<gpio_num_t>(gpio);
     txCfg.clk_src = RMT_CLK_SRC_DEFAULT;
     txCfg.resolution_hz = resolutionHz;
-    // Two memory blocks of symbols ping-pong so the DMA-less channel can refill
-    // while sending — the classic anti-glitch shape. The per-channel block size
-    // is a chip fact (64 words classic, 48 on the S3 — a hardcoded 64 makes
-    // rmt_new_tx_channel reject S3); the copy encoder streams from our buffer
-    // regardless.
+    // DMA-less chips refill the channel from interrupts; the per-channel block
+    // size is a chip fact (64 words classic, 48 on the S3 family).
     txCfg.mem_block_symbols = SOC_RMT_MEM_WORDS_PER_CHANNEL;
     txCfg.trans_queue_depth = 4;
     txCfg.flags.invert_out = invert ? 1 : 0;
@@ -304,7 +304,18 @@ size_t rmtWs2812RxCapture(uint8_t gpio, uint32_t resolutionHz,
 namespace {
 
 constexpr uint32_t kLoopbackResHz = 40'000'000;  // 25 ns/tick, same as the driver
-constexpr uint16_t kT0H = 14, kT1H = 28, kPeriod = 50;  // 350/700/1250 ns in ticks
+
+uint16_t loopbackTicksFromNs(uint32_t ns) {
+    uint16_t ticks = static_cast<uint16_t>(
+        (static_cast<uint64_t>(ns) * kLoopbackResHz) / 1'000'000'000ull);
+    return ticks == 0 ? 1 : ticks;
+}
+
+uint16_t clampedHighTicks(uint16_t high, uint16_t period) {
+    if (period < 2) return 1;
+    if (high == 0) return 1;
+    return high < period ? high : static_cast<uint16_t>(period - 1);
+}
 
 } // namespace
 
@@ -426,7 +437,8 @@ void captureAndVerifyFrame(uint16_t rxGpio, size_t frameBytes, size_t dataBytes,
 
 } // namespace detail
 
-RmtLoopbackResult rmtWs2812Loopback(uint8_t txGpio, uint8_t rxGpio) {
+RmtLoopbackResult rmtWs2812Loopback(uint8_t txGpio, uint8_t rxGpio,
+                                    uint32_t t0hNs, uint32_t t1hNs, uint32_t periodNs) {
     RmtLoopbackResult r;
     r.sent[0] = 0xA5; r.sent[1] = 0x00; r.sent[2] = 0xFF;  // recognisable pattern
 
@@ -434,10 +446,14 @@ RmtLoopbackResult rmtWs2812Loopback(uint8_t txGpio, uint8_t rxGpio) {
     if (!r.jumperDetected) return r;   // no point running RMT through a dead wire
 
     // Build 24 symbols (3 bytes × 8 bits, MSB-first) for the pattern.
-    const uint32_t sym0 = static_cast<uint32_t>(kT0H) | (1u << 15)
-                        | (static_cast<uint32_t>(kPeriod - kT0H) << 16);
-    const uint32_t sym1 = static_cast<uint32_t>(kT1H) | (1u << 15)
-                        | (static_cast<uint32_t>(kPeriod - kT1H) << 16);
+    const uint16_t period = loopbackTicksFromNs(periodNs);
+    const uint16_t t0h = clampedHighTicks(loopbackTicksFromNs(t0hNs), period);
+    const uint16_t t1h = clampedHighTicks(loopbackTicksFromNs(t1hNs), period);
+    const uint16_t threshold = static_cast<uint16_t>((t0h + t1h) / 2);
+    const uint32_t sym0 = static_cast<uint32_t>(t0h) | (1u << 15)
+                        | (static_cast<uint32_t>(period - t0h) << 16);
+    const uint32_t sym1 = static_cast<uint32_t>(t1h) | (1u << 15)
+                        | (static_cast<uint32_t>(period - t1h) << 16);
     constexpr size_t kBits = 24;
     uint32_t txSymbols[kBits];
     size_t s = 0;
@@ -476,7 +492,7 @@ RmtLoopbackResult rmtWs2812Loopback(uint8_t txGpio, uint8_t rxGpio) {
         // Decode the first 24 captured symbols → bytes (HIGH closer to T1H = 1).
         for (size_t b = 0; b < kBits; b++) {
             uint16_t high = static_cast<uint16_t>(rxSymbols[b] & 0x7FFF);
-            uint8_t bit = (high >= ((kT0H + kT1H) / 2)) ? 1 : 0;
+            uint8_t bit = (high >= threshold) ? 1 : 0;
             r.got[b / 8] = static_cast<uint8_t>((r.got[b / 8] << 1) | bit);
         }
         r.pass = (r.got[0] == r.sent[0] && r.got[1] == r.sent[1] && r.got[2] == r.sent[2]);
@@ -493,7 +509,8 @@ RmtLoopbackResult rmtWs2812Loopback(uint8_t txGpio, uint8_t rxGpio) {
 // a long wire under whatever RF the device is doing — so it catches the
 // frame-rate corruption and interference the short test is blind to.
 RmtLoopbackResult rmtWs2812LoopbackFrame(uint8_t txGpio, uint8_t rxGpio,
-                                         uint16_t lights, uint8_t channels) {
+                                         uint16_t lights, uint8_t channels,
+                                         uint32_t t0hNs, uint32_t t1hNs, uint32_t periodNs) {
     RmtLoopbackResult r;
     r.sent[0] = 0xA5; r.sent[1] = 0x00; r.sent[2] = 0xFF;
     if (lights == 0 || channels < 3 || channels > 4) return r;
@@ -501,10 +518,14 @@ RmtLoopbackResult rmtWs2812LoopbackFrame(uint8_t txGpio, uint8_t rxGpio,
     r.jumperDetected = detail::loopbackJumperOk(txGpio, rxGpio);
     if (!r.jumperDetected) return r;
 
-    const uint32_t sym0 = static_cast<uint32_t>(kT0H) | (1u << 15)
-                        | (static_cast<uint32_t>(kPeriod - kT0H) << 16);
-    const uint32_t sym1 = static_cast<uint32_t>(kT1H) | (1u << 15)
-                        | (static_cast<uint32_t>(kPeriod - kT1H) << 16);
+    const uint16_t period = loopbackTicksFromNs(periodNs);
+    const uint16_t t0h = clampedHighTicks(loopbackTicksFromNs(t0hNs), period);
+    const uint16_t t1h = clampedHighTicks(loopbackTicksFromNs(t1hNs), period);
+    const uint16_t threshold = static_cast<uint16_t>((t0h + t1h) / 2);
+    const uint32_t sym0 = static_cast<uint32_t>(t0h) | (1u << 15)
+                        | (static_cast<uint32_t>(period - t0h) << 16);
+    const uint32_t sym1 = static_cast<uint32_t>(t1h) | (1u << 15)
+                        | (static_cast<uint32_t>(period - t1h) << 16);
     const uint8_t bitsPerLight = static_cast<uint8_t>(channels * 8);
 #if !SOC_RMT_SUPPORT_DMA
     // No RMT DMA (classic ESP32): the RX capture can hold at most one hardware
@@ -573,7 +594,7 @@ RmtLoopbackResult rmtWs2812LoopbackFrame(uint8_t txGpio, uint8_t rxGpio,
         size_t mismatch = SIZE_MAX;
         for (size_t b = 0; b < kBits; b++) {
             const uint16_t high = static_cast<uint16_t>(rxSymbols[b] & 0x7FFF);
-            const uint8_t bit = (high >= ((kT0H + kT1H) / 2)) ? 1 : 0;
+            const uint8_t bit = (high >= threshold) ? 1 : 0;
             const uint8_t pos = static_cast<uint8_t>(b % bitsPerLight);
             const uint8_t expByte = (pos / 8u) < 3 ? r.sent[pos / 8u] : 0x00;
             const uint8_t exp = (expByte >> (7 - (pos & 7))) & 1u;
@@ -588,7 +609,7 @@ RmtLoopbackResult rmtWs2812LoopbackFrame(uint8_t txGpio, uint8_t rxGpio,
         const size_t lightStart = badLight * bitsPerLight;
         for (size_t b = 0; b < 24 && lightStart + b < cap.got; b++) {
             const uint8_t bit = ((rxSymbols[lightStart + b] & 0x7FFF)
-                                 >= ((kT0H + kT1H) / 2)) ? 1 : 0;
+                                 >= threshold) ? 1 : 0;
             r.got[b / 8] = static_cast<uint8_t>((r.got[b / 8] << 1) | bit);
         }
     }

--- a/src/platform/esp32/platform_esp32_rmt.cpp
+++ b/src/platform/esp32/platform_esp32_rmt.cpp
@@ -43,7 +43,16 @@ struct RmtTxState {
     rmt_channel_handle_t channel = nullptr;
     rmt_encoder_handle_t encoder = nullptr;
     uint32_t resolutionHz = 0;
+    bool withDma = false;
+    volatile bool busy = false;
 };
+
+bool IRAM_ATTR rmtTxDoneCb(rmt_channel_handle_t, const rmt_tx_done_event_data_t*,
+                           void* user) {
+    auto* st = static_cast<RmtTxState*>(user);
+    if (st) st->busy = false;
+    return false;
+}
 
 } // namespace
 
@@ -51,6 +60,30 @@ bool rmtWs2812Init(RmtWs2812Handle& h, uint8_t gpio, uint32_t resolutionHz, bool
     auto* st = new (std::nothrow) RmtTxState();
     if (!st) return false;
 
+#if SOC_RMT_SUPPORT_DMA
+    auto makeCfg = [&](bool withDma) {
+        rmt_tx_channel_config_t txCfg = {};
+        txCfg.gpio_num = static_cast<gpio_num_t>(gpio);
+        txCfg.clk_src = RMT_CLK_SRC_DEFAULT;
+        txCfg.resolution_hz = resolutionHz;
+        txCfg.mem_block_symbols = withDma ? 1024 : SOC_RMT_MEM_WORDS_PER_CHANNEL;
+        txCfg.trans_queue_depth = 4;
+        txCfg.flags.invert_out = invert ? 1 : 0;
+        txCfg.flags.with_dma = withDma ? 1 : 0;
+        return txCfg;
+    };
+    rmt_tx_channel_config_t txCfg = makeCfg(true);
+    esp_err_t chanErr = rmt_new_tx_channel(&txCfg, &st->channel);
+    if (chanErr != ESP_OK) {
+        txCfg = makeCfg(false);
+        chanErr = rmt_new_tx_channel(&txCfg, &st->channel);
+    }
+    if (chanErr != ESP_OK) {
+        delete st;
+        return false;
+    }
+    st->withDma = txCfg.flags.with_dma != 0;
+#else
     rmt_tx_channel_config_t txCfg = {};
     txCfg.gpio_num = static_cast<gpio_num_t>(gpio);
     txCfg.clk_src = RMT_CLK_SRC_DEFAULT;
@@ -68,9 +101,19 @@ bool rmtWs2812Init(RmtWs2812Handle& h, uint8_t gpio, uint32_t resolutionHz, bool
         delete st;
         return false;
     }
+#endif
 
     rmt_copy_encoder_config_t copyCfg = {};
     if (rmt_new_copy_encoder(&copyCfg, &st->encoder) != ESP_OK) {
+        rmt_del_channel(st->channel);
+        delete st;
+        return false;
+    }
+
+    rmt_tx_event_callbacks_t cbs = {};
+    cbs.on_trans_done = rmtTxDoneCb;
+    if (rmt_tx_register_event_callbacks(st->channel, &cbs, st) != ESP_OK) {
+        rmt_del_encoder(st->encoder);
         rmt_del_channel(st->channel);
         delete st;
         return false;
@@ -93,9 +136,16 @@ uint32_t rmtWs2812Resolution(const RmtWs2812Handle& h) {
     return st ? st->resolutionHz : 0;
 }
 
+const char* rmtWs2812Backend(const RmtWs2812Handle& h) {
+    auto* st = static_cast<RmtTxState*>(h.impl);
+    if (!st) return "none";
+    return st->withDma ? "RMT DMA" : "RMT";
+}
+
 bool rmtWs2812Transmit(RmtWs2812Handle& h, const uint32_t* symbols, size_t symbolCount) {
     auto* st = static_cast<RmtTxState*>(h.impl);
     if (!st || !symbols || symbolCount == 0) return false;
+    if (st->busy) return false;
 
     rmt_transmit_config_t txCfg = {};
     txCfg.loop_count = 0;   // single shot, no hardware loop
@@ -105,8 +155,16 @@ bool rmtWs2812Transmit(RmtWs2812Handle& h, const uint32_t* symbols, size_t symbo
     // clock out concurrently, which is what makes a multi-pin frame cost the
     // longest strand instead of the sum. The caller pairs this with
     // rmtWs2812Wait and owns the inter-frame latch after the last wait.
-    return rmt_transmit(st->channel, st->encoder, symbols,
-                        symbolCount * sizeof(uint32_t), &txCfg) == ESP_OK;
+    st->busy = true;
+    const esp_err_t err = rmt_transmit(st->channel, st->encoder, symbols,
+                                       symbolCount * sizeof(uint32_t), &txCfg);
+    if (err != ESP_OK) st->busy = false;
+    return err == ESP_OK;
+}
+
+bool rmtWs2812Busy(const RmtWs2812Handle& h) {
+    auto* st = static_cast<RmtTxState*>(h.impl);
+    return st && st->busy;
 }
 
 void rmtWs2812Wait(RmtWs2812Handle& h, uint32_t timeoutMs) {
@@ -125,12 +183,16 @@ void rmtWs2812Wait(RmtWs2812Handle& h, uint32_t timeoutMs) {
     // and calls rmt_transmit again; if the channel is still busy, rmt_transmit
     // returns an error, rmtWs2812Transmit returns false, and RmtLedDriver::loop()
     // skips waiting on that channel (its started[] guard) — no crash, no corruption.
-    rmt_tx_wait_all_done(st->channel, timeoutMs);
+    if (rmt_tx_wait_all_done(st->channel, timeoutMs) == ESP_OK) st->busy = false;
 }
 
 void rmtWs2812Deinit(RmtWs2812Handle& h) {
     auto* st = static_cast<RmtTxState*>(h.impl);
     if (!st) return;
+    if (st->busy) {
+        rmt_tx_wait_all_done(st->channel, 250);
+        st->busy = false;
+    }
     if (st->channel) {
         rmt_disable(st->channel);
         rmt_del_channel(st->channel);

--- a/src/platform/esp32/platform_esp32_rmt.cpp
+++ b/src/platform/esp32/platform_esp32_rmt.cpp
@@ -190,7 +190,7 @@ void rmtWs2812Deinit(RmtWs2812Handle& h) {
     auto* st = static_cast<RmtTxState*>(h.impl);
     if (!st) return;
     if (st->busy) {
-        rmt_tx_wait_all_done(st->channel, 250);
+        if (rmt_tx_wait_all_done(st->channel, 250) != ESP_OK) return;
         st->busy = false;
     }
     if (st->channel) {

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -430,10 +430,9 @@ uint32_t rmtWs2812Resolution(const RmtWs2812Handle& h);
 const char* rmtWs2812Backend(const RmtWs2812Handle& h);
 
 // Start transmitting `symbolCount` pre-encoded WS2812 RMT symbols and return
-// immediately — channels started back-to-back clock out concurrently. Pair with
-// rmtWs2812Wait; the caller owns the inter-frame latch (delayUs) after the last
-// wait. The symbol buffer must stay valid until the wait returns. Returns false
-// when the channel isn't initialised (and on targets without RMT).
+// immediately — channels started back-to-back clock out concurrently. The symbol
+// buffer must stay valid while rmtWs2812Busy() is true. Returns false when the
+// channel isn't initialised, already busy, or on targets without RMT.
 bool rmtWs2812Transmit(RmtWs2812Handle& h, const uint32_t* symbols, size_t symbolCount);
 
 // True while a previously-started frame is still being clocked out by the RMT
@@ -441,11 +440,8 @@ bool rmtWs2812Transmit(RmtWs2812Handle& h, const uint32_t* symbols, size_t symbo
 // overwriting a symbol buffer still owned by DMA/RMT.
 bool rmtWs2812Busy(const RmtWs2812Handle& h);
 
-// Block until the channel's in-flight transmission finishes, bounded by
-// `timeoutMs` so a wedged peripheral can't hang the render tick forever — a
-// timed-out frame is simply dropped and re-encoded next tick (self-heals). With
-// N channels waited sequentially the worst case is N×timeoutMs; acceptable for
-// the same self-healing reason.
+// Legacy/blocking wait for diagnostics and loopback tests. Runtime LED output
+// should prefer rmtWs2812Busy() and skip stale frames instead of waiting here.
 void rmtWs2812Wait(RmtWs2812Handle& h, uint32_t timeoutMs);
 
 void rmtWs2812Deinit(RmtWs2812Handle& h);
@@ -470,7 +466,8 @@ struct RmtLoopbackResult {
     uint32_t bitsChecked = 0;     // total WS2812 bits verified (frame mode); 24 for the short test
     uint32_t firstBadBit = 0;     // index of the first wrong bit, or bitsChecked when all pass
 };
-RmtLoopbackResult rmtWs2812Loopback(uint8_t txGpio, uint8_t rxGpio);
+RmtLoopbackResult rmtWs2812Loopback(uint8_t txGpio, uint8_t rxGpio,
+                                    uint32_t t0hNs, uint32_t t1hNs, uint32_t periodNs);
 
 // Whole-FRAME RMT loopback: instead of a 24-bit synthetic burst, transmit a
 // real `lights`-light WS2812 frame (the per-light pattern 0xA5/0x00/0xFF
@@ -480,7 +477,8 @@ RmtLoopbackResult rmtWs2812Loopback(uint8_t txGpio, uint8_t rxGpio);
 // the data line that a 24-bit burst can't — a single flipped bit anywhere in
 // the frame fails the test and reports its position. No-op off ESP32.
 RmtLoopbackResult rmtWs2812LoopbackFrame(uint8_t txGpio, uint8_t rxGpio,
-                                         uint16_t lights, uint8_t channels);
+                                         uint16_t lights, uint8_t channels,
+                                         uint32_t t0hNs, uint32_t t1hNs, uint32_t periodNs);
 
 // ---------------------------------------------------------------------------
 // LCD_CAM parallel WS2812 output (ESP32-S3). The driver

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -426,12 +426,20 @@ bool rmtWs2812Init(RmtWs2812Handle& h, uint8_t gpio, uint32_t resolutionHz, bool
 // The driver converts its ns timings to ticks with this. 0 if not initialised.
 uint32_t rmtWs2812Resolution(const RmtWs2812Handle& h);
 
+// Human-readable backend name for diagnostics ("RMT DMA", "RMT", "none").
+const char* rmtWs2812Backend(const RmtWs2812Handle& h);
+
 // Start transmitting `symbolCount` pre-encoded WS2812 RMT symbols and return
 // immediately — channels started back-to-back clock out concurrently. Pair with
 // rmtWs2812Wait; the caller owns the inter-frame latch (delayUs) after the last
 // wait. The symbol buffer must stay valid until the wait returns. Returns false
 // when the channel isn't initialised (and on targets without RMT).
 bool rmtWs2812Transmit(RmtWs2812Handle& h, const uint32_t* symbols, size_t symbolCount);
+
+// True while a previously-started frame is still being clocked out by the RMT
+// peripheral. Used by non-blocking LED drivers to skip stale frames instead of
+// overwriting a symbol buffer still owned by DMA/RMT.
+bool rmtWs2812Busy(const RmtWs2812Handle& h);
 
 // Block until the channel's in-flight transmission finishes, bounded by
 // `timeoutMs` so a wedged peripheral can't hang the render tick forever — a

--- a/test/unit/light/unit_Correction.cpp
+++ b/test/unit/light/unit_Correction.cpp
@@ -71,7 +71,7 @@ TEST_CASE("Correction BGR preset: full reverse") {
     CHECK(out[2] == 10);  // R
 }
 
-// RGBW preset adds a fourth white channel derived as min(R, G, B) per pixel.
+// RGBW preset adds a fourth white channel derived as min(R, G, B) for RGB-only pixels.
 TEST_CASE("Correction RGBW preset: 4 channels, white = min(r,g,b)") {
     Correction c;
     c.rebuild(255, LightPreset::RGBW);
@@ -86,6 +86,19 @@ TEST_CASE("Correction RGBW preset: 4 channels, white = min(r,g,b)") {
     CHECK(out[3] == 10);  // W = min(10,20,30)
 }
 
+// RGBW layers carry a real W byte; preserve it instead of re-deriving white from RGB.
+TEST_CASE("Correction RGBW preset: explicit source white wins when present") {
+    Correction c;
+    c.rebuild(255, LightPreset::RGBW);
+    const uint8_t src[4] = {10, 20, 30, 200};
+    uint8_t out[4] = {};
+    c.apply(src, out, 4);
+    CHECK(out[0] == 10);
+    CHECK(out[1] == 20);
+    CHECK(out[2] == 30);
+    CHECK(out[3] == 200);
+}
+
 // GRBW preset combines the GRB reorder with the W derivation (G, R, B, W=min).
 TEST_CASE("Correction GRBW preset: reordered RGB + white") {
     Correction c;
@@ -98,6 +111,21 @@ TEST_CASE("Correction GRBW preset: reordered RGB + white") {
     CHECK(out[1] == 10);  // R
     CHECK(out[2] == 30);  // B
     CHECK(out[3] == 10);  // W = min
+}
+
+// WGRB covers white-first RGBW pixels found on some SK6812-compatible strips.
+TEST_CASE("Correction WGRB preset: white can be first") {
+    Correction c;
+    c.rebuild(255, LightPreset::WGRB);
+    CHECK(c.outChannels == 4);
+    CHECK(c.deriveWhite);
+    const uint8_t src[3] = {10, 20, 30};
+    uint8_t out[4] = {};
+    c.apply(src, out);
+    CHECK(out[0] == 10);  // W = min
+    CHECK(out[1] == 20);  // G
+    CHECK(out[2] == 10);  // R
+    CHECK(out[3] == 30);  // B
 }
 
 // Brightness scaling runs before white derivation so W = min of the *scaled* RGB values.

--- a/test/unit/light/unit_RmtLedEncoder.cpp
+++ b/test/unit/light/unit_RmtLedEncoder.cpp
@@ -101,3 +101,20 @@ TEST_CASE("encoder: RGBW preset yields 32 symbols per light") {
     CHECK(h0.level == 1);
     CHECK((h0.duration == T0H || h0.duration == T1H));
 }
+
+TEST_CASE("encoder: explicit RGBW white channel reaches the last wire byte") {
+    mm::Correction c;
+    c.rebuild(255, mm::LightPreset::GRBW);  // G,R,B,W
+    const uint8_t logical[4] = {0, 0, 0, 0xFF};
+    uint8_t wire[4] = {};
+    c.apply(logical, wire, 4);
+    CHECK(wire[0] == 0x00);
+    CHECK(wire[1] == 0x00);
+    CHECK(wire[2] == 0x00);
+    CHECK(wire[3] == 0xFF);
+
+    uint32_t out[32] = {};
+    mm::encodeWs2812Symbols(wire, c.outChannels, T0H, T1H, PERIOD, out);
+    for (int i = 0; i < 24; i++) checkBit(out[i], T0H);
+    for (int i = 24; i < 32; i++) checkBit(out[i], T1H);
+}


### PR DESCRIPTION
## Summary
- add scheduler frame pacing with a configurable FPS cap and staggered housekeeping
- avoid frequent LittleFS usage scans from File Manager
- make ESP32 RMT LED output non-blocking, use DMA when available, and expose backend/frame-skip telemetry
- add RGB/RGBW color-order presets, SK6812 timing selection, and correction/encoder coverage

## Validation
- `git diff --check origin/main..HEAD`
- `moondeck/check/check_specs.py`
- `moondeck/check/check_platform_boundary.py`
- product-specific string scan on the PR diff
- `moondeck/build/build_esp32.py --firmware esp32s3-n16r8`
- `esp32s3-n16r8` image: `0x17f4a0`, 63% app partition free

## Not Run
- Desktop CMake/ctest: CMake is not available in this shell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable WS2812B and SK6812 RGBW LED chipset profiles.
  * Expanded RGB/RGBW color-order presets, including explicit white-channel support.
  * Added configurable frame-rate cap from 10–120 FPS.
  * Added LED backend and frame-status reporting, including DMA availability.

* **Bug Fixes**
  * Improved LED transmission handling when a previous frame is still busy.
  * Reduced filesystem usage refresh frequency to improve runtime efficiency.

* **Documentation**
  * Updated LED driver documentation with chipset, backend, and supported peripheral details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->